### PR TITLE
FieldRange for GridView filters

### DIFF
--- a/assets/css/field-range.css
+++ b/assets/css/field-range.css
@@ -58,3 +58,54 @@
     border-top-left-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
 }
+
+.grid-view .form-control::-moz-placeholder {
+	color: #ccc;
+}
+.grid-view .form-control:-ms-input-placeholder {
+	color: #ccc;
+}
+.grid-view .form-control::-webkit-input-placeholder {
+	color: #ccc;
+}
+
+.grid-view .input-daterange input  {
+	text-align: left;
+}
+
+.grid-view .kv-field-from .form-control, .grid-view .kv-field-from.form-control {
+	border-radius: 4px !important;
+    border-bottom-right-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+	border-bottom-width: 0;
+}
+
+.grid-view .kv-field-to .form-control, .grid-view .kv-field-to.form-control {
+	border-radius: 4px !important;
+    border-top-right-radius: 0 !important;
+    border-top-left-radius: 0 !important;
+}
+
+.grid-view .kv-field-from .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-down {
+	border-bottom-width: 0;
+    border-bottom-right-radius: 0;
+}
+
+.grid-view .kv-field-to .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-up {
+	border-bottom-width: 0;
+    border-top-right-radius: 0;
+	padding-bottom: 9px;
+}
+
+.grid-view .form-group {
+	margin-bottom: 0; 
+}
+
+.grid-view .help-block {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.grid-view span.input-group-addon.kv-field-separator {
+	display: none;
+}

--- a/assets/css/field-range.css
+++ b/assets/css/field-range.css
@@ -86,12 +86,12 @@
     border-top-left-radius: 0 !important;
 }
 
-.grid-view .kv-field-from .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-down {
+.grid-view .kv-container-from .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-down {
 	border-bottom-width: 0;
     border-bottom-right-radius: 0;
 }
 
-.grid-view .kv-field-to .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-up {
+.grid-view .kv-container-to .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-up {
 	border-bottom-width: 0;
     border-top-right-radius: 0;
 	padding-bottom: 9px;

--- a/field/FieldRange.php
+++ b/field/FieldRange.php
@@ -342,16 +342,10 @@ class FieldRange extends \yii\base\Widget
     public function initOptions()
     {
         Html::addCssClass($this->labelOptions, 'control-label');
-        Html::addCssClass($this->options1, 'kv-field-from');
-        Html::addCssClass($this->options2, 'kv-field-to');
+        Html::addCssClass($this->options1, 'kv-field-from form-control');
+        Html::addCssClass($this->options2, 'kv-field-to form-control');
         if (in_array($this->type, self::$_inputWidgets)) {
             $this->widgetClass = $this->type;
-        }
-        if ($this->_isInput && empty($this->options1['class'])) {
-            Html::addCssClass($this->options1, 'form-control');
-        }
-        if ($this->_isInput && empty($this->options2['class'])) {
-            Html::addCssClass($this->options2, 'form-control');
         }
         if (empty($this->options['id'])) {
             $this->options['id'] = $this->getId();

--- a/field/FieldRange.php
+++ b/field/FieldRange.php
@@ -8,6 +8,7 @@
 
 namespace kartik\field;
 
+use Yii;
 use yii\base\Model;
 use yii\web\View;
 use yii\helpers\Json;
@@ -303,13 +304,13 @@ class FieldRange extends \yii\base\Widget
             $widget = isset($this->form) ? $this->getFormInput() : $this->getInput(1) .
                 '<span class="input-group-addon kv-field-separator">' . $this->separator . '</span>' .
                 $this->getInput(2);
-            $widget = Html::tag('div', $widget, $this->options);
-        }
+            $widget = Html::tag('div', $widget, $this->separator ? $this->options : []);
+         }
         $widget = Html::tag('div', $widget, $this->widgetContainer);
         $error = Html::tag('div', '<div class="help-block"></div>', $this->errorContainer);
 
         echo Html::tag('div', strtr($this->template, [
-            '{label}' => Html::label($this->label, null, $this->labelOptions),
+            '{label}' =>$this->separator ?  Html::label($this->label, null, $this->labelOptions) : '',
             '{widget}' => $widget,
             '{error}' => $error
         ]), $this->container);
@@ -340,6 +341,8 @@ class FieldRange extends \yii\base\Widget
     public function initOptions()
     {
         Html::addCssClass($this->labelOptions, 'control-label');
+        Html::addCssClass($this->options1, 'kv-field-from');
+        Html::addCssClass($this->options2, 'kv-field-to');
         if (in_array($this->type, self::$_inputWidgets)) {
             $this->widgetClass = $this->type;
         }
@@ -361,6 +364,10 @@ class FieldRange extends \yii\base\Widget
         if (empty($this->errorContainer['id'])) {
             $this->errorContainer['id'] = $this->options1['id'] . '-error';
         }
+		if(empty($this->separator)) {
+			$this->options1['placeholder'] = Yii::t('app', 'From');
+			$this->options2['placeholder'] = Yii::t('app', 'To');
+		}
         $this->container['id'] = $this->options['id'] . '-container';
     }
 
@@ -374,7 +381,7 @@ class FieldRange extends \yii\base\Widget
         $class = self::INPUT_DATE;
         $this->widgetOptions1['type'] = $class::TYPE_RANGE;
         $this->widgetOptions1['separator'] = $this->separator;
-        if ($this->hasModel()) {
+       if ($this->hasModel()) {
             $this->widgetOptions1 = ArrayHelper::merge($this->widgetOptions1, [
                 'model' => $this->model,
                 'attribute' => $this->attribute1,
@@ -395,6 +402,12 @@ class FieldRange extends \yii\base\Widget
         if (isset($this->form)) {
             $this->widgetOptions1['form'] = $this->form;
         }
+		if(empty($this->separator)) {
+			$this->widgetOptions1['options']['placeholder'] = Yii::t('app', 'From');
+            Html::addCssClass($this->widgetOptions1['options'], 'kv-field-from');
+		}
+ 		$this->widgetOptions1['options']['placeholder'] = 'From';
+		
         return $class::widget($this->widgetOptions1);
     }
 
@@ -413,8 +426,8 @@ class FieldRange extends \yii\base\Widget
         Html::addCssClass($options2, 'kv-container-to form-control');
         $this->fieldConfig1 = ArrayHelper::merge($this->fieldConfig1, ['template' => '{input}{error}', 'options' => $options1]);
         $this->fieldConfig2 = ArrayHelper::merge($this->fieldConfig2, ['template' => '{input}{error}', 'options' => $options2]);
-        Html::addCssClass($this->options1, 'form-control kv-field-from');
-        Html::addCssClass($this->options2, 'form-control kv-field-to');
+        Html::addCssClass($this->options1, 'form-control');
+        Html::addCssClass($this->options2, 'form-control');
         $field1 = $this->form->field($this->model, $this->attribute1, $this->fieldConfig1);
         $field2 = $this->form->field($this->model, $this->attribute2, $this->fieldConfig2);
         if ($this->type === self::INPUT_HTML5_INPUT) {

--- a/field/FieldRange.php
+++ b/field/FieldRange.php
@@ -301,9 +301,10 @@ class FieldRange extends \yii\base\Widget
         } else {
             Html::addCssClass($this->container, 'form-group');
             Html::addCssClass($this->options, 'input-group');
-            $widget = isset($this->form) ? $this->getFormInput() : $this->getInput(1) .
+
+            $widget = isset($this->form) ? $this->getFormInput() : Html::tag('div', $this->getInput(1), ['class' => 'kv-container-from']) .
                 '<span class="input-group-addon kv-field-separator">' . $this->separator . '</span>' .
-                $this->getInput(2);
+                Html::tag('div', $this->getInput(2), ['class' => 'kv-container-to']);
             $widget = Html::tag('div', $widget, $this->separator ? $this->options : []);
          }
         $widget = Html::tag('div', $widget, $this->widgetContainer);


### PR DESCRIPTION
Altered FieldRange.php to assume vertical stacking of inputs when separator is empty. This meant adding from and to container and input classes in a couple of places to make selecting the inputs for styling easier and more generic - was initially difficult to identify and style some of the top and bottom borders of the from and to widgets in css (not sure if they were deliberately missing or accidentally missing).

Have tested and working for my use for date, datetime, money, ordinary text input, and spin. Note that have only styled spins vertical buttons, and the money widget won't show placeholders if allowZero is true until the plugin author merges pull request 110 to allow nulls - this currently causes 0.00 ti show instead of the greyed placeholder text "From" and "To".

In order to use in GridView need to add the new attributes into the search model, search model rules e.g.

class AccountSearch extends Account
{
    public $from_annual_charge;
    public $to_annual_charge;
    public $from_balance;
    public $to_balance;
    public $from_booking_charge;
    public $to_booking_charge;
    public $from_rate;
    public $to_rate;
    public $from_seat_charge;
    public $to_seat_charge;
    public $from_sms_charge;
    public $to_sms_charge;
    public $from_summary_charge;
    public $to_summary_charge;
    public $from_ticket_charge;
    public $to_ticket_charge;

```
public function rules()
{
    return [
        [['address_id', 'user_id'], 'integer'],
        [['annual_charge', 'from_annual_charge', 'to_annual_charge', 'balance', 'from_balance', 'to_balance', 'booking_charge', 'from_booking_charge', 'to_booking_charge', 'rate', 'from_rate', 'to_rate', 'seat_charge', 'from_seat_charge', 'to_seat_charge', 'sms_charge', 'from_sms_charge', 'to_sms_charge', 'summary_charge', 'from_summary_charge', 'to_summary_charge', 'ticket_charge', 'from_ticket_charge', 'to_ticket_charge'], 'number'],
        [['phone_work'], 'safe'],
    ];
}

public function scenarios()
{
    // bypass scenarios() implementation in the parent class
    return \yii\base\Model::scenarios();
}

public function search($params)
{
    $query = Account::find();

    $dataProvider = new ActiveDataProvider([
        'query' => $query,
    ]);

    if (!($this->load($params) && $this->validate())) {
        return $dataProvider;
    }

    $query->andFilterWhere(['address_id' => $this->address_id]);
    if(!is_null($this->from_annual_charge) && $this->from_annual_charge != '') $query->andWhere('`annual_charge` >= :from_annual_charge', [':from_annual_charge' => $this->from_annual_charge]);
    if(!is_null($this->to_annual_charge) && $this->to_annual_charge != '') $query->andWhere('`annual_charge` <= :to_annual_charge', [':to_annual_charge' => $this->to_annual_charge]);
    if(!is_null($this->from_balance) && $this->from_balance != '') $query->andWhere('`balance` >= :from_balance', [':from_balance' => $this->from_balance]);
    if(!is_null($this->to_balance) && $this->to_balance != '') $query->andWhere('`balance` <= :to_balance', [':to_balance' => $this->to_balance]);
    if(!is_null($this->from_booking_charge) && $this->from_booking_charge != '') $query->andWhere('`booking_charge` >= :from_booking_charge', [':from_booking_charge' => $this->from_booking_charge]);
    if(!is_null($this->to_booking_charge) && $this->to_booking_charge != '') $query->andWhere('`booking_charge` <= :to_booking_charge', [':to_booking_charge' => $this->to_booking_charge]);
    $query->andFilterWhere(['like', 'phone_work', $this->phone_work]);
    if(!is_null($this->from_rate) && $this->from_rate != '') $query->andWhere('`rate` >= :from_rate', [':from_rate' => $this->from_rate]);
    if(!is_null($this->to_rate) && $this->to_rate != '') $query->andWhere('`rate` <= :to_rate', [':to_rate' => $this->to_rate]);
    if(!is_null($this->from_seat_charge) && $this->from_seat_charge != '') $query->andWhere('`seat_charge` >= :from_seat_charge', [':from_seat_charge' => $this->from_seat_charge]);
    if(!is_null($this->to_seat_charge) && $this->to_seat_charge != '') $query->andWhere('`seat_charge` <= :to_seat_charge', [':to_seat_charge' => $this->to_seat_charge]);
    if(!is_null($this->from_sms_charge) && $this->from_sms_charge != '') $query->andWhere('`sms_charge` >= :from_sms_charge', [':from_sms_charge' => $this->from_sms_charge]);
    if(!is_null($this->to_sms_charge) && $this->to_sms_charge != '') $query->andWhere('`sms_charge` <= :to_sms_charge', [':to_sms_charge' => $this->to_sms_charge]);
    if(!is_null($this->from_summary_charge) && $this->from_summary_charge != '') $query->andWhere('`summary_charge` >= :from_summary_charge', [':from_summary_charge' => $this->from_summary_charge]);
    if(!is_null($this->to_summary_charge) && $this->to_summary_charge != '') $query->andWhere('`summary_charge` <= :to_summary_charge', [':to_summary_charge' => $this->to_summary_charge]);
    if(!is_null($this->from_ticket_charge) && $this->from_ticket_charge != '') $query->andWhere('`ticket_charge` >= :from_ticket_charge', [':from_ticket_charge' => $this->from_ticket_charge]);
    if(!is_null($this->to_ticket_charge) && $this->to_ticket_charge != '') $query->andWhere('`ticket_charge` <= :to_ticket_charge', [':to_ticket_charge' => $this->to_ticket_charge]);
    $query->andFilterWhere(['user_id' => $this->user_id]);

    return $dataProvider;
}
```

}
