### PR TITLE
Enhance to accept hash var load position as parameter

### DIFF
--- a/src/FieldRange.php
+++ b/src/FieldRange.php
@@ -694,7 +694,7 @@ class FieldRange extends Widget
         );
         $hashVar = $name . '_' . hash('crc32', $options);
         $this->options['data-krajee-' . $name] = $hashVar;
-        $view->registerJs("var {$hashVar} = {$options};\n", View::POS_HEAD);
+        $view->registerJs("var {$hashVar} = {$options};\n", $this->hashVarLoadPosition);
         $view->registerJs("{$id}.{$name}({$hashVar});");
     }
 


### PR DESCRIPTION
change View::POS_HEAD to $this->hashVarLoadPosition, to support rendering the widget via `renderAjax`

## Scope
This pull request includes a

- [ ] New feature

## Changes
The following changes were made:

- View::POS_HEAD to $this->hashVarLoadPosition
